### PR TITLE
ISSUE ANDROID-197 1.1.7 - 1.2.11 Crash from crashlytics - BT Adapter …

### DIFF
--- a/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviRangeNotifier.kt
+++ b/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviRangeNotifier.kt
@@ -62,7 +62,9 @@ class RuuviRangeNotifier(
         crashResolver.start()
     }
 
-    override fun canScan(): Boolean = bluetoothAdapter != null && scanner != null
+    @SuppressLint("MissingPermission")
+    override fun canScan(): Boolean =
+        bluetoothAdapter != null && scanner != null && bluetoothAdapter?.state == BluetoothAdapter.STATE_ON
 
     @SuppressLint("MissingPermission")
     override fun stopScanning() {


### PR DESCRIPTION
…is not turned ON

[FIXED] checking BT state when start to scan