### PR TITLE
ISSUE ANDROID-197 1.1.7 - 1.2.11 Crash from crashlytics - BT Adapter …

### DIFF
--- a/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviRangeNotifier.kt
+++ b/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviRangeNotifier.kt
@@ -28,7 +28,6 @@ class RuuviRangeNotifier(
                 .build()
 
     private val isScanning = AtomicBoolean(false)
-    private val crashResolver = BluetoothCrashResolver(context)
 
     init {
         Timber.d("[$from] Setting up range notifier")
@@ -59,7 +58,6 @@ class RuuviRangeNotifier(
 
         this.tagListener = foundListener
         scanner?.startScan(getScanFilters(), scanSettings, scanCallback)
-        crashResolver.start()
     }
 
     @SuppressLint("MissingPermission")


### PR DESCRIPTION
…is not turned ON

[FIXED] checking BT state when start to scan