### PR TITLE
ISSUE #413 GATT sync occasionally gives a Disconnected pop-up

### DIFF
--- a/default_bluetooth_library/build.gradle
+++ b/default_bluetooth_library/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 10203
-        versionName "1.2.3"
+        versionCode 10204
+        versionName "1.2.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/GattConnection.kt
+++ b/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/GattConnection.kt
@@ -10,7 +10,7 @@ import java.util.*
 import kotlin.concurrent.schedule
 
 class GattConnection(context: Context, var device: BluetoothDevice) {
-    lateinit var mBluetoothGatt: BluetoothGatt
+    private lateinit var mBluetoothGatt: BluetoothGatt
     var syncFrom: Date? = null
     var listener: IRuuviGattListener? = null
     var logs = mutableListOf<LogReading>()
@@ -30,6 +30,11 @@ class GattConnection(context: Context, var device: BluetoothDevice) {
 
     fun log(message: String) {
         Timber.d("${mBluetoothGatt.device.address} GATT: $message")
+    }
+
+    fun resetState() {
+        retryConnectionCounter = 0
+        mBluetoothGatt.close()
     }
 
     private fun writeRXCharacteristic(value: ByteArray): Boolean {

--- a/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviRangeNotifier.kt
+++ b/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviRangeNotifier.kt
@@ -71,7 +71,7 @@ class RuuviRangeNotifier(
         bluetoothAdapter != null && scanner != null && bluetoothAdapter?.state == BluetoothAdapter.STATE_ON
 
     fun getTagConnection(macAddress: String): GattConnection? {
-        return tagConnections.findLast { it.mBluetoothGatt.device.address.toString() == macAddress }
+        return tagConnections.findLast { it.device.address.toString() == macAddress }
     }
 
     override fun connect(macAddress: String, readLogsFrom: Date?, listener: IRuuviGattListener): Boolean {
@@ -87,7 +87,7 @@ class RuuviRangeNotifier(
                     return connected
                 } else {
                     gattConnection.let { gatt ->
-                        gatt.mBluetoothGatt.close()
+                        gatt.resetState()
                         gatt.setOnRuuviGattUpdate(listener)
                         return gatt.connect(context, readLogsFrom)
                     }


### PR DESCRIPTION
[FIXED] resetting state of GattConnection should help to prevent disconnected message on successful sync