### PR TITLE
ISSUE #290 Redundant timestamp on the background scanning notificatio…

### DIFF
--- a/default_bluetooth_library/build.gradle
+++ b/default_bluetooth_library/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 10204
-        versionName "1.2.4"
+        versionCode 10205
+        versionName "1.2.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/BluetoothForegroundService.kt
+++ b/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/BluetoothForegroundService.kt
@@ -50,6 +50,7 @@ class BluetoothForegroundService : Service(), KodeinAware {
             setSmallIcon(scannerSettings.getNotificationIconId())
             setContentTitle(scannerSettings.getNotificationTitle())
             setContentText(scannerSettings.getNotificationText())
+            setShowWhen(false)
             setStyle(NotificationCompat.BigTextStyle())
             setNumber(0)
             scannerSettings.getNotificationPendingIntent()?.let { pendingIntent ->


### PR DESCRIPTION
…n bar

[FIXED] timestamp for foreground service is hidden now