### PR TITLE
Fix BLE scanning fallback for devices without extended advertising

### DIFF
--- a/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviTagScanner.kt
+++ b/default_bluetooth_library/src/main/java/com/ruuvi/station/bluetooth/RuuviTagScanner.kt
@@ -39,7 +39,7 @@ class RuuviTagScanner(
                         .setReportDelay(0)
                         .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isLeExtendedAdvertisingSupported) {
                 scanSettings.setLegacy(false)
             }
             return scanSettings.build()
@@ -52,7 +52,7 @@ class RuuviTagScanner(
                     .setReportDelay(0)
                     .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isLeExtendedAdvertisingSupported) {
                 scanSettings.setLegacy(false)
             }
             return scanSettings.build()


### PR DESCRIPTION
Check isLeExtendedAdvertisingSupported before disabling legacy mode, allowing devices to fall back to legacy scanning when extended advertising is not supported.